### PR TITLE
Off-chain worker sending http request as text/plain

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,10 +29,16 @@ git = 'https://github.com/paritytech/substrate.git'
 tag = 'v2.0.0-alpha.8'
 version = '2.0.0-alpha.8'
 
-[dependencies.fixed]
+# [dependencies.fixed]
+# default-features = false
+# git = "https://github.com/encointer/substrate-fixed"
+# package = "substrate-fixed"
+
+[dependencies.product-registry]
 default-features = false
-git = "https://github.com/encointer/substrate-fixed"
-package = "substrate-fixed"
+git = 'https://github.com/stiiifff/pallet-product-registry'
+package = 'pallet-product-registry'
+# version = '0.0.1'
 
 [dev-dependencies.sp-core]
 default-features = false
@@ -58,4 +64,5 @@ std = [
     'codec/std',
     'frame-support/std',
     'frame-system/std',
+    'product-registry/std'
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,10 @@ git = 'https://github.com/paritytech/substrate.git'
 tag = 'v2.0.0-rc3'
 version = '2.0.0-rc3'
 
-[dependencies.frame-system]
+[dependencies.system]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
+package = 'frame-system'
 tag = 'v2.0.0-rc3'
 version = '2.0.0-rc3'
 
@@ -38,9 +39,9 @@ version = '2.0.0-rc3'
 default-features = false
 git = 'https://github.com/stiiifff/pallet-product-registry'
 package = 'pallet-product-registry'
-# version = '0.0.1'
+version = '0.0.1'
 
-[dev-dependencies.sp-core]
+[dependencies.sp-core]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
 tag = 'v2.0.0-rc3'
@@ -49,6 +50,12 @@ version = '2.0.0-rc3'
 [dev-dependencies.sp-io]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
+tag = 'v2.0.0-rc3'
+version = '2.0.0-rc3'
+
+[dependencies.sp-std]
+git = 'https://github.com/paritytech/substrate.git'
+default-features = false
 tag = 'v2.0.0-rc3'
 version = '2.0.0-rc3'
 
@@ -70,7 +77,7 @@ default = ['std']
 std = [
     'codec/std',
     'frame-support/std',
-    'frame-system/std',
+    'system/std',
     'timestamp/std',
     'product-registry/std'
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,14 +20,14 @@ version = '1.3.0'
 [dependencies.frame-support]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-tag = 'v2.0.0-alpha.8'
-version = '2.0.0-alpha.8'
+tag = 'v2.0.0-rc3'
+version = '2.0.0-rc3'
 
 [dependencies.frame-system]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-tag = 'v2.0.0-alpha.8'
-version = '2.0.0-alpha.8'
+tag = 'v2.0.0-rc3'
+version = '2.0.0-rc3'
 
 # [dependencies.fixed]
 # default-features = false
@@ -43,20 +43,27 @@ package = 'pallet-product-registry'
 [dev-dependencies.sp-core]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-tag = 'v2.0.0-alpha.8'
-version = '2.0.0-alpha.8'
+tag = 'v2.0.0-rc3'
+version = '2.0.0-rc3'
 
 [dev-dependencies.sp-io]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-tag = 'v2.0.0-alpha.8'
-version = '2.0.0-alpha.8'
+tag = 'v2.0.0-rc3'
+version = '2.0.0-rc3'
 
 [dev-dependencies.sp-runtime]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-tag = 'v2.0.0-alpha.8'
-version = '2.0.0-alpha.8'
+tag = 'v2.0.0-rc3'
+version = '2.0.0-rc3'
+
+[dependencies.timestamp]
+default_features = false
+git = 'https://github.com/paritytech/substrate.git'
+package = 'pallet-timestamp'
+tag = 'v2.0.0-rc3'
+version = '2.0.0-rc3'
 
 [features]
 default = ['std']
@@ -64,5 +71,6 @@ std = [
     'codec/std',
     'frame-support/std',
     'frame-system/std',
+    'timestamp/std',
     'product-registry/std'
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
-description = 'Substrate FRAME pallet template'
+description = 'Substrate Enterprise Sample - Product Tracking example pallet'
 edition = '2018'
 homepage = 'https://substrate.io'
 license = 'Unlicense'
-name = 'pallet-template'
+name = 'pallet-product-tracking'
 repository = 'https://github.com/paritytech/substrate/'
-version = '2.0.0-alpha.8'
+version = '0.0.1'
 
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']
@@ -28,6 +28,11 @@ default-features = false
 git = 'https://github.com/paritytech/substrate.git'
 tag = 'v2.0.0-alpha.8'
 version = '2.0.0-alpha.8'
+
+[dependencies.fixed]
+default-features = false
+git = "https://github.com/encointer/substrate-fixed"
+package = "substrate-fixed"
 
 [dev-dependencies.sp-core]
 default-features = false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@ pub trait Trait: system::Trait + timestamp::Trait {
 }
 
 decl_storage! {
-    trait Store for Module<T: Trait> as TemplateModule {
+    trait Store for Module<T: Trait> as ProductTracking {
         pub EventCount: u64;
         pub AllEvents: map hasher(blake2_128_concat) u64 => Option<EventRecord<T::Moment>>;
         pub EventIndices get(fn event_by_id): map hasher(blake2_128_concat) EventId => Option<u64>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,10 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
-/// A FRAME pallet template with necessary imports
-
-/// Feel free to remove or edit this file as needed.
-/// If you change the name of this file, make sure to update its references in runtime/src/lib.rs
-/// If you remove this file, you can remove those references
-
-/// For more guidance on Substrate FRAME, see the example pallet
-/// https://github.com/paritytech/substrate/blob/master/frame/example/src/lib.rs
-
-use frame_support::{decl_module, decl_storage, decl_event, decl_error, dispatch};
+use codec::{Decode, Encode};
+use fixed::types::I16F16;
+use frame_support::{
+    decl_error, decl_event, decl_module, decl_storage, dispatch, sp_runtime::RuntimeDebug,
+};
 use frame_system::{self as system, ensure_signed};
 
 #[cfg(test)]
@@ -18,92 +13,54 @@ mod mock;
 #[cfg(test)]
 mod tests;
 
-/// The pallet's configuration trait.
+#[derive(Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug)]
+pub struct EventRecord {
+    event_type: Vec<u8>,
+    product_id: Vec<u8>,
+    org_id: Vec<u8>,
+    timestamp: Vec<u8>,
+    location: Vec<u8>,
+    readings: Vec<u8>,
+}
+
+#[derive(Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug)]
+pub struct ReadPoint {
+    pub latitude: I16F16,
+}
+
 pub trait Trait: system::Trait {
-	// Add other types and constants required to configure this pallet.
-
-	/// The overarching event type.
-	type Event: From<Event<Self>> + Into<<Self as system::Trait>::Event>;
+    type Event: From<Event<Self>> + Into<<Self as system::Trait>::Event>;
 }
 
-// This pallet's storage items.
 decl_storage! {
-	// It is important to update your storage name so that your pallet's
-	// storage items are isolated from other pallets.
-	// ---------------------------------vvvvvvvvvvvvvv
-	trait Store for Module<T: Trait> as TemplateModule {
-		// Just a dummy storage item.
-		// Here we are declaring a StorageValue, `Something` as a Option<u32>
-		// `get(fn something)` is the default getter which returns either the stored `u32` or `None` if nothing stored
-		Something get(fn something): Option<u32>;
-	}
+    trait Store for Module<T: Trait> as TemplateModule {
+    }
 }
 
-// The pallet's events
 decl_event!(
-	pub enum Event<T> where AccountId = <T as system::Trait>::AccountId {
-		/// Just a dummy event.
-		/// Event `Something` is declared with a parameter of the type `u32` and `AccountId`
-		/// To emit this event, we call the deposit function, from our runtime functions
-		SomethingStored(u32, AccountId),
-	}
+    pub enum Event<T>
+    where
+        AccountId = <T as system::Trait>::AccountId,
+    {
+        EventTracked(AccountId),
+    }
 );
 
-// The pallet's errors
 decl_error! {
-	pub enum Error for Module<T: Trait> {
-		/// Value was None
-		NoneValue,
-		/// Value reached maximum and cannot be incremented further
-		StorageOverflow,
-	}
+    pub enum Error for Module<T: Trait> {
+    }
 }
 
-// The pallet's dispatchable functions.
 decl_module! {
-	/// The module declaration.
-	pub struct Module<T: Trait> for enum Call where origin: T::Origin {
-		// Initializing errors
-		// this includes information about your errors in the node's metadata.
-		// it is needed only if you are using errors in your pallet
-		type Error = Error<T>;
+    pub struct Module<T: Trait> for enum Call where origin: T::Origin {
+        type Error = Error<T>;
+        fn deposit_event() = default;
 
-		// Initializing events
-		// this is needed only if you are using events in your pallet
-		fn deposit_event() = default;
+        #[weight = 10_000]
+        pub fn record_event(origin, event: EventRecord) -> dispatch::DispatchResult {
+            let who = ensure_signed(origin)?;
 
-		/// Just a dummy entry point.
-		/// function that can be called by the external world as an extrinsics call
-		/// takes a parameter of the type `AccountId`, stores it, and emits an event
-		#[weight = 10_000]
-		pub fn do_something(origin, something: u32) -> dispatch::DispatchResult {
-			// Check it was signed and get the signer. See also: ensure_root and ensure_none
-			let who = ensure_signed(origin)?;
-
-			// Code to execute when something calls this.
-			// For example: the following line stores the passed in u32 in the storage
-			Something::put(something);
-
-			// Here we are raising the Something event
-			Self::deposit_event(RawEvent::SomethingStored(something, who));
-			Ok(())
-		}
-
-		/// Another dummy entry point.
-		/// takes no parameters, attempts to increment storage value, and possibly throws an error
-		#[weight = 10_000]
-		pub fn cause_error(origin) -> dispatch::DispatchResult {
-			// Check it was signed and get the signer. See also: ensure_root and ensure_none
-			let _who = ensure_signed(origin)?;
-
-			match Something::get() {
-				None => Err(Error::<T>::NoneValue)?,
-				Some(old) => {
-					let new = old.checked_add(1).ok_or(Error::<T>::StorageOverflow)?;
-					Something::put(new);
-					Ok(())
-				},
-			}
-		}
-	}
+            Ok(())
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,32 @@ decl_module! {
         type Error = Error<T>;
         fn deposit_event() = default;
 
-        // pub fn register_shipment()
+        #[weight = 10_000]
+        pub fn register_shipment(origin, id: ShipmentId, owner: T::AccountId, products: Vec<ProductId>) -> dispatch::DispatchResult {
+            let who = ensure_signed(origin)?;
+
+            // TODO: assuming owner is a DID representing an organization,
+            //       validate tx sender is owner or delegate of organization.
+
+            // Validate product IDs
+            // Self::validate_product_id(&id)?;
+
+            // Create a product instance
+            // let product = Self::new_product()
+            //     .identified_by(id.clone())
+            //     .owned_by(owner.clone())
+            //     .registered_on(<timestamp::Module<T>>::now())
+            //     .with_props(props)
+            //     .build();
+
+            // // Add product & ownerOf (2 DB writes)
+            // <Products<T>>::insert(&id, product);
+            // <OwnerOf<T>>::insert(&id, &owner);
+
+            // Self::deposit_event(RawEvent::ProductRegistered(who, id, owner));
+
+            Ok(())
+        }
 
         #[weight = 10_000]
         pub fn record_event(origin, event: EventRecord<T::Moment>) -> dispatch::DispatchResult {
@@ -120,6 +145,53 @@ decl_module! {
             Self::deposit_event(RawEvent::EventRecorded(who));
 
             Ok(())
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct ShipmentBuilder<AccountId, Moment>
+where
+    AccountId: Default,
+    Moment: Default,
+{
+    id: ShipmentId,
+    owner: AccountId,
+    products: Vec<ProductId>,
+    registered: Moment,
+}
+
+impl<AccountId, Moment> ShipmentBuilder<AccountId, Moment>
+where
+    AccountId: Default,
+    Moment: Default,
+{
+    pub fn identified_by(mut self, id: ShipmentId) -> Self {
+        self.id = id;
+        self
+    }
+
+    pub fn owned_by(mut self, owner: AccountId) -> Self {
+        self.owner = owner;
+        self
+    }
+
+    pub fn with_products(mut self, products: Vec<ProductId>) -> Self {
+        self.products = products;
+        self
+    }
+
+    pub fn registered_on(mut self, registered: Moment) -> Self {
+        self.registered = registered;
+        self
+    }
+
+    pub fn build(self) -> Shipment<AccountId, Moment> {
+        Shipment::<AccountId, Moment> {
+            id: self.id,
+            owner: self.owner,
+            products: self.products,
+            registered: self.registered,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,12 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use codec::{Decode, Encode};
-use fixed::types::I16F16;
+// use fixed::types::I16F16;
 use frame_support::{
     decl_error, decl_event, decl_module, decl_storage, dispatch, sp_runtime::RuntimeDebug,
 };
 use frame_system::{self as system, ensure_signed};
+use product_registry::ProductId;
 
 #[cfg(test)]
 mod mock;
@@ -13,19 +14,21 @@ mod mock;
 #[cfg(test)]
 mod tests;
 
+// Custom types
+pub type EventType = Vec<u8>;
+
 #[derive(Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug)]
-pub struct EventRecord {
-    event_type: Vec<u8>,
-    product_id: Vec<u8>,
-    org_id: Vec<u8>,
-    timestamp: Vec<u8>,
+pub struct EventRecord<Moment> {
+    event: EventType,
+    products: Vec<ProductId>,
+    timestamp: Moment,
     location: Vec<u8>,
     readings: Vec<u8>,
 }
 
 #[derive(Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug)]
 pub struct ReadPoint {
-    pub latitude: I16F16,
+    pub latitude: Vec<u8>,
 }
 
 pub trait Trait: system::Trait {

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -2,7 +2,6 @@
 
 use crate::{Module, Trait};
 use frame_support::{impl_outer_origin, parameter_types, weights::Weight};
-use frame_system as system;
 use sp_core::{sr25519, Pair, H256};
 use sp_runtime::{
     testing::Header,

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -1,15 +1,17 @@
 // Creating mock runtime here
 
 use crate::{Module, Trait};
-use sp_core::H256;
 use frame_support::{impl_outer_origin, parameter_types, weights::Weight};
-use sp_runtime::{
-	traits::{BlakeTwo256, IdentityLookup}, testing::Header, Perbill,
-};
 use frame_system as system;
+use sp_core::{sr25519, Pair, H256};
+use sp_runtime::{
+    testing::Header,
+    traits::{BlakeTwo256, IdentityLookup},
+    Perbill,
+};
 
 impl_outer_origin! {
-	pub enum Origin for Test {}
+    pub enum Origin for Test {}
 }
 
 // For testing the pallet, we construct most of a mock runtime. This means
@@ -18,42 +20,61 @@ impl_outer_origin! {
 #[derive(Clone, Eq, PartialEq)]
 pub struct Test;
 parameter_types! {
-	pub const BlockHashCount: u64 = 250;
-	pub const MaximumBlockWeight: Weight = 1024;
-	pub const MaximumBlockLength: u32 = 2 * 1024;
-	pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
+    pub const BlockHashCount: u64 = 250;
+    pub const MaximumBlockWeight: Weight = 1024;
+    pub const MaximumBlockLength: u32 = 2 * 1024;
+    pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
 }
 impl system::Trait for Test {
-	type Origin = Origin;
-	type Call = ();
-	type Index = u64;
-	type BlockNumber = u64;
-	type Hash = H256;
-	type Hashing = BlakeTwo256;
-	type AccountId = u64;
-	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
-	type Event = ();
-	type BlockHashCount = BlockHashCount;
-	type MaximumBlockWeight = MaximumBlockWeight;
-	type DbWeight = ();
-	type BlockExecutionWeight = ();
-	type ExtrinsicBaseWeight = ();
-	type MaximumBlockLength = MaximumBlockLength;
-	type AvailableBlockRatio = AvailableBlockRatio;
-	type Version = ();
-	type ModuleToIndex = ();
-	type AccountData = ();
-	type OnNewAccount = ();
-	type OnKilledAccount = ();
+    type Origin = Origin;
+    type Call = ();
+    type Index = u64;
+    type BlockNumber = u64;
+    type Hash = H256;
+    type Hashing = BlakeTwo256;
+    type AccountId = sr25519::Public;
+    type Lookup = IdentityLookup<Self::AccountId>;
+    type Header = Header;
+    type Event = ();
+    type BlockHashCount = BlockHashCount;
+    type MaximumBlockWeight = MaximumBlockWeight;
+    type DbWeight = ();
+    type BlockExecutionWeight = ();
+    type ExtrinsicBaseWeight = ();
+    type MaximumExtrinsicWeight = MaximumBlockWeight;
+    type MaximumBlockLength = MaximumBlockLength;
+    type AvailableBlockRatio = AvailableBlockRatio;
+    type Version = ();
+    type ModuleToIndex = ();
+    type AccountData = ();
+    type OnNewAccount = ();
+    type OnKilledAccount = ();
 }
+
+impl timestamp::Trait for Test {
+    type Moment = u64;
+    type OnTimestampSet = ();
+    type MinimumPeriod = ();
+}
+
 impl Trait for Test {
-	type Event = ();
+    type Event = ();
 }
-pub type TemplateModule = Module<Test>;
+
+pub type ProductTracking = Module<Test>;
+pub type Timestamp = timestamp::Module<Test>;
 
 // This function basically just builds a genesis storage key/value store according to
 // our desired mockup.
 pub fn new_test_ext() -> sp_io::TestExternalities {
-	system::GenesisConfig::default().build_storage::<Test>().unwrap().into()
+    system::GenesisConfig::default()
+        .build_storage::<Test>()
+        .unwrap()
+        .into()
+}
+
+pub fn account_key(s: &str) -> sr25519::Public {
+    sr25519::Pair::from_string(&format!("//{}", s), None)
+        .expect("static values are valid; qed")
+        .public()
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -4,17 +4,17 @@ use super::*;
 use crate::{mock::*, Error};
 use frame_support::{assert_noop, assert_ok, dispatch};
 
-pub fn store_test_shipment<T: Trait>(id: ShipmentId, owner: T::AccountId, registered: T::Moment) {
-    Shipments::<T>::insert(
-        id.clone(),
-        Shipment {
-            id,
-            owner,
-            products: vec![],
-            registered,
-        },
-    );
-}
+// pub fn store_test_shipment<T: Trait>(id: ShipmentId, owner: T::AccountId, registered: T::Moment) {
+//     Shipments::<T>::insert(
+//         id.clone(),
+//         Shipment {
+//             id,
+//             owner,
+//             products_filter: vec![],
+//             registered,
+//         },
+//     );
+// }
 
 const TEST_PRODUCT_ID: &str = "00012345600012";
 const TEST_SHIPMENT_ID: &str = "000123456";
@@ -54,139 +54,139 @@ const LONG_VALUE : &str = "Lorem ipsum dolor sit amet, consectetur adipiscing el
 //     });
 // }
 
-#[test]
-fn create_shipment_with_valid_products() {
-    new_test_ext().execute_with(|| {
-        let sender = account_key(TEST_SENDER);
-        let id = TEST_SHIPMENT_ID.as_bytes().to_owned();
-        let owner = account_key(TEST_ORGANIZATION);
-        let now = 42;
-        Timestamp::set_timestamp(now);
+// // #[test]
+// // fn create_shipment_with_valid_products() {
+// //     new_test_ext().execute_with(|| {
+// //         let sender = account_key(TEST_SENDER);
+// //         let id = TEST_SHIPMENT_ID.as_bytes().to_owned();
+// //         let owner = account_key(TEST_ORGANIZATION);
+// //         let now = 42;
+// //         Timestamp::set_timestamp(now);
 
-        let result = ProductTracking::register_shipment(
-            Origin::signed(sender),
-            id.clone(),
-            owner.clone(),
-            vec![
-                b"00012345600001".to_vec(),
-                b"00012345600002".to_vec(),
-                b"00012345600003".to_vec(),
-            ],
-        );
+// //         let result = ProductTracking::register_shipment(
+// //             Origin::signed(sender),
+// //             id.clone(),
+// //             owner.clone(),
+// //             vec![
+// //                 b"00012345600001".to_vec(),
+// //                 b"00012345600002".to_vec(),
+// //                 b"00012345600003".to_vec(),
+// //             ],
+// //         );
 
-        assert_ok!(result);
+// //         assert_ok!(result);
 
-        assert_eq!(
-            ProductTracking::shipment_by_id(&id),
-            Some(Shipment {
-                id: id.clone(),
-                owner: owner,
-                registered: now,
-                products: vec![
-                    b"00012345600001".to_vec(),
-                    b"00012345600002".to_vec(),
-                    b"00012345600003".to_vec(),
-                ],
-            })
-        );
-    });
-}
+// //         // assert_eq!(
+// //         //     ProductTracking::shipment_by_id(&id),
+// //         //     Some(Shipment {
+// //         //         id: id.clone(),
+// //         //         owner: owner,
+// //         //         registered: now,
+// //         //         products: vec![
+// //         //             b"00012345600001".to_vec(),
+// //         //             b"00012345600002".to_vec(),
+// //         //             b"00012345600003".to_vec(),
+// //         //         ],
+// //         //     })
+// //         // );
+// //     });
+// // }
 
-#[test]
-fn create_shipment_with_invalid_sender() {
-    new_test_ext().execute_with(|| {
-        assert_noop!(
-            ProductTracking::register_shipment(
-                Origin::NONE,
-                TEST_SHIPMENT_ID.as_bytes().to_owned(),
-                account_key(TEST_ORGANIZATION),
-                vec!()
-            ),
-            dispatch::DispatchError::BadOrigin
-        );
-    });
-}
+// // #[test]
+// // fn create_shipment_with_invalid_sender() {
+// //     new_test_ext().execute_with(|| {
+// //         assert_noop!(
+// //             ProductTracking::register_shipment(
+// //                 Origin::NONE,
+// //                 TEST_SHIPMENT_ID.as_bytes().to_owned(),
+// //                 account_key(TEST_ORGANIZATION),
+// //                 vec!()
+// //             ),
+// //             dispatch::DispatchError::BadOrigin
+// //         );
+// //     });
+// // }
 
-#[test]
-fn create_shipment_with_missing_id() {
-    new_test_ext().execute_with(|| {
-        assert_noop!(
-            ProductTracking::register_shipment(
-                Origin::signed(account_key(TEST_SENDER)),
-                vec!(),
-                account_key(TEST_ORGANIZATION),
-                vec!()
-            ),
-            Error::<Test>::ShipmentIdMissing
-        );
-    });
-}
+// // #[test]
+// // fn create_shipment_with_missing_id() {
+// //     new_test_ext().execute_with(|| {
+// //         assert_noop!(
+// //             ProductTracking::register_shipment(
+// //                 Origin::signed(account_key(TEST_SENDER)),
+// //                 vec!(),
+// //                 account_key(TEST_ORGANIZATION),
+// //                 vec!()
+// //             ),
+// //             Error::<Test>::ShipmentIdMissing
+// //         );
+// //     });
+// // }
 
-#[test]
-fn create_shipment_with_long_id() {
-    new_test_ext().execute_with(|| {
-        assert_noop!(
-            ProductTracking::register_shipment(
-                Origin::signed(account_key(TEST_SENDER)),
-                LONG_VALUE.as_bytes().to_owned(),
-                account_key(TEST_ORGANIZATION),
-                vec!()
-            ),
-            Error::<Test>::ShipmentIdTooLong
-        );
-    })
-}
+// // #[test]
+// // fn create_shipment_with_long_id() {
+// //     new_test_ext().execute_with(|| {
+// //         assert_noop!(
+// //             ProductTracking::register_shipment(
+// //                 Origin::signed(account_key(TEST_SENDER)),
+// //                 LONG_VALUE.as_bytes().to_owned(),
+// //                 account_key(TEST_ORGANIZATION),
+// //                 vec!()
+// //             ),
+// //             Error::<Test>::ShipmentIdTooLong
+// //         );
+// //     })
+// // }
 
-#[test]
-fn create_shipment_with_existing_id() {
-    new_test_ext().execute_with(|| {
-        let existing_shipment = TEST_SHIPMENT_ID.as_bytes().to_owned();
-        let now = 42;
+// // #[test]
+// // fn create_shipment_with_existing_id() {
+// //     new_test_ext().execute_with(|| {
+// //         let existing_shipment = TEST_SHIPMENT_ID.as_bytes().to_owned();
+// //         let now = 42;
 
-        store_test_shipment::<Test>(
-            existing_shipment.clone(),
-            account_key(TEST_ORGANIZATION),
-            now,
-        );
+// //         store_test_shipment::<Test>(
+// //             existing_shipment.clone(),
+// //             account_key(TEST_ORGANIZATION),
+// //             now,
+// //         );
 
-        assert_noop!(
-            ProductTracking::register_shipment(
-                Origin::signed(account_key(TEST_SENDER)),
-                existing_shipment,
-                account_key(TEST_ORGANIZATION),
-                vec![]
-            ),
-            Error::<Test>::ShipmentIdExists
-        );
-    })
-}
+// //         assert_noop!(
+// //             ProductTracking::register_shipment(
+// //                 Origin::signed(account_key(TEST_SENDER)),
+// //                 existing_shipment,
+// //                 account_key(TEST_ORGANIZATION),
+// //                 vec![]
+// //             ),
+// //             Error::<Test>::ShipmentIdExists
+// //         );
+// //     })
+// // }
 
-#[test]
-fn create_shipment_with_too_many_products() {
-    new_test_ext().execute_with(|| {
-        assert_noop!(
-            ProductTracking::register_shipment(
-                Origin::signed(account_key(TEST_SENDER)),
-                TEST_SHIPMENT_ID.as_bytes().to_owned(),
-                account_key(TEST_ORGANIZATION),
-                vec![
-                    b"00012345600001".to_vec(),
-                    b"00012345600002".to_vec(),
-                    b"00012345600003".to_vec(),
-                    b"00012345600004".to_vec(),
-                    b"00012345600005".to_vec(),
-                    b"00012345600006".to_vec(),
-                    b"00012345600007".to_vec(),
-                    b"00012345600008".to_vec(),
-                    b"00012345600009".to_vec(),
-                    b"00012345600010".to_vec(),
-                    b"00012345600011".to_vec(),
-                ]
-            ),
-            Error::<Test>::ShipmentTooManyProducts
-        );
-    })
-}
+// // #[test]
+// // fn create_shipment_with_too_many_products() {
+//     new_test_ext().execute_with(|| {
+//         assert_noop!(
+//             ProductTracking::register_shipment(
+//                 Origin::signed(account_key(TEST_SENDER)),
+//                 TEST_SHIPMENT_ID.as_bytes().to_owned(),
+//                 account_key(TEST_ORGANIZATION),
+//                 vec![
+//                     b"00012345600001".to_vec(),
+//                     b"00012345600002".to_vec(),
+//                     b"00012345600003".to_vec(),
+//                     b"00012345600004".to_vec(),
+//                     b"00012345600005".to_vec(),
+//                     b"00012345600006".to_vec(),
+//                     b"00012345600007".to_vec(),
+//                     b"00012345600008".to_vec(),
+//                     b"00012345600009".to_vec(),
+//                     b"00012345600010".to_vec(),
+//                     b"00012345600011".to_vec(),
+//                 ]
+//             ),
+//             Error::<Test>::ShipmentTooManyProducts
+//         );
+//     })
+// }
 
 // #[test]
 // fn create_product_with_invalid_prop_name() {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,4 +1,227 @@
 // Tests to be written here
 
+use super::*;
 use crate::{mock::*, Error};
-use frame_support::{assert_noop, assert_ok};
+use frame_support::{assert_noop, assert_ok, dispatch};
+
+pub fn store_test_shipment<T: Trait>(id: ShipmentId, owner: T::AccountId, registered: T::Moment) {
+    Shipments::<T>::insert(
+        id.clone(),
+        Shipment {
+            id,
+            owner,
+            products: vec![],
+            registered,
+        },
+    );
+}
+
+const TEST_PRODUCT_ID: &str = "00012345600012";
+const TEST_SHIPMENT_ID: &str = "000123456";
+const TEST_ORGANIZATION: &str = "Northwind";
+const TEST_SENDER: &str = "Alice";
+const LONG_VALUE : &str = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec aliquam ut tortor nec congue. Pellente";
+
+// #[test]
+// fn create_product_without_props() {
+//     new_test_ext().execute_with(|| {
+//         let sender = account_key(TEST_SENDER);
+//         let id = TEST_PRODUCT_ID.as_bytes().to_owned();
+//         let owner = account_key(TEST_ORGANIZATION);
+//         let now = 42;
+//         Timestamp::set_timestamp(now);
+
+//         let result = ProductTracking::register_product(
+//             Origin::signed(sender),
+//             id.clone(),
+//             owner.clone(),
+//             None,
+//         );
+
+//         assert_ok!(result);
+
+//         assert_eq!(
+//             ProductTracking::product_by_id(&id),
+//             Some(Product {
+//                 id: id.clone(),
+//                 owner: owner,
+//                 registered: now,
+//                 props: None
+//             })
+//         );
+
+//         assert_eq!(ProductTracking::owner_of(&id), Some(owner));
+//     });
+// }
+
+#[test]
+fn create_shipment_with_valid_products() {
+    new_test_ext().execute_with(|| {
+        let sender = account_key(TEST_SENDER);
+        let id = TEST_SHIPMENT_ID.as_bytes().to_owned();
+        let owner = account_key(TEST_ORGANIZATION);
+        let now = 42;
+        Timestamp::set_timestamp(now);
+
+        let result = ProductTracking::register_shipment(
+            Origin::signed(sender),
+            id.clone(),
+            owner.clone(),
+            vec![
+                b"00012345600001".to_vec(),
+                b"00012345600002".to_vec(),
+                b"00012345600003".to_vec(),
+            ],
+        );
+
+        assert_ok!(result);
+
+        assert_eq!(
+            ProductTracking::shipment_by_id(&id),
+            Some(Shipment {
+                id: id.clone(),
+                owner: owner,
+                registered: now,
+                products: vec![
+                    b"00012345600001".to_vec(),
+                    b"00012345600002".to_vec(),
+                    b"00012345600003".to_vec(),
+                ],
+            })
+        );
+    });
+}
+
+#[test]
+fn create_shipment_with_invalid_sender() {
+    new_test_ext().execute_with(|| {
+        assert_noop!(
+            ProductTracking::register_shipment(
+                Origin::NONE,
+                TEST_SHIPMENT_ID.as_bytes().to_owned(),
+                account_key(TEST_ORGANIZATION),
+                vec!()
+            ),
+            dispatch::DispatchError::BadOrigin
+        );
+    });
+}
+
+#[test]
+fn create_shipment_with_missing_id() {
+    new_test_ext().execute_with(|| {
+        assert_noop!(
+            ProductTracking::register_shipment(
+                Origin::signed(account_key(TEST_SENDER)),
+                vec!(),
+                account_key(TEST_ORGANIZATION),
+                vec!()
+            ),
+            Error::<Test>::ShipmentIdMissing
+        );
+    });
+}
+
+#[test]
+fn create_shipment_with_long_id() {
+    new_test_ext().execute_with(|| {
+        assert_noop!(
+            ProductTracking::register_shipment(
+                Origin::signed(account_key(TEST_SENDER)),
+                LONG_VALUE.as_bytes().to_owned(),
+                account_key(TEST_ORGANIZATION),
+                vec!()
+            ),
+            Error::<Test>::ShipmentIdTooLong
+        );
+    })
+}
+
+#[test]
+fn create_shipment_with_existing_id() {
+    new_test_ext().execute_with(|| {
+        let existing_shipment = TEST_SHIPMENT_ID.as_bytes().to_owned();
+        let now = 42;
+
+        store_test_shipment::<Test>(
+            existing_shipment.clone(),
+            account_key(TEST_ORGANIZATION),
+            now,
+        );
+
+        assert_noop!(
+            ProductTracking::register_shipment(
+                Origin::signed(account_key(TEST_SENDER)),
+                existing_shipment,
+                account_key(TEST_ORGANIZATION),
+                vec![]
+            ),
+            Error::<Test>::ShipmentIdExists
+        );
+    })
+}
+
+#[test]
+fn create_shipment_with_too_many_products() {
+    new_test_ext().execute_with(|| {
+        assert_noop!(
+            ProductTracking::register_shipment(
+                Origin::signed(account_key(TEST_SENDER)),
+                TEST_SHIPMENT_ID.as_bytes().to_owned(),
+                account_key(TEST_ORGANIZATION),
+                vec![
+                    b"00012345600001".to_vec(),
+                    b"00012345600002".to_vec(),
+                    b"00012345600003".to_vec(),
+                    b"00012345600004".to_vec(),
+                    b"00012345600005".to_vec(),
+                    b"00012345600006".to_vec(),
+                    b"00012345600007".to_vec(),
+                    b"00012345600008".to_vec(),
+                    b"00012345600009".to_vec(),
+                    b"00012345600010".to_vec(),
+                    b"00012345600011".to_vec(),
+                ]
+            ),
+            Error::<Test>::ShipmentTooManyProducts
+        );
+    })
+}
+
+// #[test]
+// fn create_product_with_invalid_prop_name() {
+//     new_test_ext().execute_with(|| {
+//         assert_noop!(
+//             ProductTracking::register_product(
+//                 Origin::signed(account_key(TEST_SENDER)),
+//                 TEST_PRODUCT_ID.as_bytes().to_owned(),
+//                 account_key(TEST_ORGANIZATION),
+//                 Some(vec![
+//                     ProductProperty::new(b"prop1", b"val1"),
+//                     ProductProperty::new(b"prop2", b"val2"),
+//                     ProductProperty::new(&LONG_VALUE.as_bytes().to_owned(), b"val3"),
+//                 ])
+//             ),
+//             Error::<Test>::ProductInvalidPropName
+//         );
+//     })
+// }
+
+// #[test]
+// fn create_product_with_invalid_prop_value() {
+//     new_test_ext().execute_with(|| {
+//         assert_noop!(
+//             ProductTracking::register_product(
+//                 Origin::signed(account_key(TEST_SENDER)),
+//                 TEST_PRODUCT_ID.as_bytes().to_owned(),
+//                 account_key(TEST_ORGANIZATION),
+//                 Some(vec![
+//                     ProductProperty::new(b"prop1", b"val1"),
+//                     ProductProperty::new(b"prop2", b"val2"),
+//                     ProductProperty::new(b"prop3", &LONG_VALUE.as_bytes().to_owned()),
+//                 ])
+//             ),
+//             Error::<Test>::ProductInvalidPropValue
+//         );
+//     })
+// }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,26 +1,4 @@
 // Tests to be written here
 
-use crate::{Error, mock::*};
-use frame_support::{assert_ok, assert_noop};
-
-#[test]
-fn it_works_for_default_value() {
-	new_test_ext().execute_with(|| {
-		// Just a dummy test for the dummy function `do_something`
-		// calling the `do_something` function with a value 42
-		assert_ok!(TemplateModule::do_something(Origin::signed(1), 42));
-		// asserting that the stored value is equal to what we stored
-		assert_eq!(TemplateModule::something(), Some(42));
-	});
-}
-
-#[test]
-fn correct_error_for_none_value() {
-	new_test_ext().execute_with(|| {
-		// Ensure the correct error is thrown on None value
-		assert_noop!(
-			TemplateModule::cause_error(Origin::signed(1)),
-			Error::<Test>::NoneValue
-		);
-	});
-}
+use crate::{mock::*, Error};
+use frame_support::{assert_noop, assert_ok};


### PR DESCRIPTION
To replace #7 

And you really want to review together with this: https://github.com/gautamdhameja/substrate-enterprise-sample/pull/9

Btw, in the serialization, now I rely on the `{:?}` Debug trait to works. So this will work in native code, but not wasm. But I don't think we are going to do runtime upgrade with this pallet so this should not hurt.

Thanks